### PR TITLE
Changed output path

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -72,7 +72,7 @@ namespace SubCheck
 
 			SolutionFile solution = null;
 			string solutionFileName = null;
-			string zipDirectoryName = Path.GetFileNameWithoutExtension(filename);
+			string zipDirectoryName = Path.GetDirectoryName(filename) + "/SubCheck/" + Path.GetFileName(filename);
 
 			try
 			{


### PR DESCRIPTION
Changed output path to a new /SubCheck/ folder to prevent SubCheck.exe from extracting the zip in the original folder that the .zip was created from. This happens if the SubCheck.exe happens to be in the same directory as the original project.
This also prevents the SubCheck.exe from evaluating the original project that may have changed since the time it was zipped.